### PR TITLE
Fix: ensure load_cookie_cache returns 6 values consistently to prevent unpacking error

### DIFF
--- a/SushiDL_V10.py
+++ b/SushiDL_V10.py
@@ -747,7 +747,7 @@ def load_cookie_cache():
     default_webp2jpg = True
     
     if not os.path.exists(COOKIE_CACHE_PATH):
-        return {}, None, default_cbz, default_fs, ""
+        return {}, None, default_cbz, default_fs, "", default_webp2jpg
     
     try:
         with open(COOKIE_CACHE_PATH, "r", encoding="utf-8") as f:


### PR DESCRIPTION
Cette PR corrige un bug dans la fonction `load_cookie_cache()` qui causait un `ValueError`  
lorsqu’elle retournait un nombre incohérent de valeurs.

---
### Détails

- Ajout de `default_webp2jpg` dans le premier return pour que la fonction retourne toujours 6 valeurs.  
- Testé localement, cela empêche l’erreur `ValueError: not enough values to unpack`.

Fixes #4

